### PR TITLE
Fix typos: "Clima" -> "Client"

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ For this project you need to connect an array of 4 Max7219 LED dot matrix to Mea
 
 ## Projects
 
-* **OnAir_Sign.Clima** - Xamarin.Forms application that listens to Maple's UDP broadcasts to obtain the server and sends GET requests to Meadow to display text on the LED display.
-* **OnAir_Sign.Clima.Android** - Android platform specific project.
-* **OnAir_Sign.Clima.iOS** - iOS platform specific project.
-* **OnAir_Sign.Clima.UWP** - UWP platform specific project.
+* **OnAir_Sign.Client** - Xamarin.Forms application that listens to Maple's UDP broadcasts to obtain the server and sends GET requests to Meadow to display text on the LED display.
+* **OnAir_Sign.Client.Android** - Android platform specific project.
+* **OnAir_Sign.Client.iOS** - iOS platform specific project.
+* **OnAir_Sign.Client.UWP** - UWP platform specific project.
 * **OnAir_Sign.Meadow** - A meadow application that runs a Maple server, broadcasting the server information in the network and taking GET requests to show text on the MAX7212 
 * **OnAir_Sign.Meadow.HackKit** - Same meadow application with the difference of using a Character Display including in the Hack Kit.
 


### PR DESCRIPTION
Looked like this might be a typo from a copy-paste from Clima stuff. If I am reading it correctly, these are all supposed to be projects named `OnAir_Sign.Client*`.

https://github.com/WildernessLabs/OnAir_Sign/tree/main/Source/OnAir_Sign/OnAir_Sign.Client